### PR TITLE
Restructure the draft to latest CDDL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,6 @@ $(drafts_xml): $(cddl_deps)
 
 $(cddl_deps): ; $(MAKE) -C cddl check
 
+cddl/%.cddl: cddl/%.cddl.in ; $(MAKE) -C cddl
+
 clean:: ; $(MAKE) -C cddl clean

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -1,6 +1,7 @@
 include tools.mk
 include check.mk
 include frags.mk
+include subst.mk
 
 check: check-coserv check-coserv-examples
 .PHONY: check

--- a/cddl/signed-coserv-headers.cddl.in
+++ b/cddl/signed-coserv-headers.cddl.in
@@ -1,0 +1,12 @@
+signed-coserv-protected-hdr = {
+  1 => int                            ; alg
+  2 => "application/coserv+cbor" / TBD1 ; cty
+  * cose.label => cose.values
+}
+
+signed-coserv-unprotected-hdr = {
+  * cose.label => cose.values
+}
+
+cose.label = int / text
+cose.values = any

--- a/cddl/signed-coserv.cddl
+++ b/cddl/signed-coserv.cddl
@@ -1,0 +1,6 @@
+signed-coserv = [
+  protected: bytes .cbor signed-coserv-protected-hdr
+  unprotected: signed-coserv-unprotected-hdr
+  payload: bytes .cbor coserv
+  signature: bytes
+]

--- a/cddl/subst.mk
+++ b/cddl/subst.mk
@@ -1,0 +1,3 @@
+signed-coserv-headers.cddl: signed-coserv-headers.cddl.in ; sed -e 's/TBD1/10000/' $< > $@
+
+CLEANFILES += signed-coserv-headers.cddl

--- a/draft-howard-rats-coserv.md
+++ b/draft-howard-rats-coserv.md
@@ -58,8 +58,8 @@ entity:
 --- abstract
 
 In the Remote Attestation Procedures (RATS) architecture, Verifiers require Endorsements and Reference Values to assess the trustworthiness of Attesters.
-This document specifies the Concise Selector for Endorsements and Reference Values (CoSERV), a structured query format designed to facilitate the discovery and retrieval of these artifacts from various providers.
-CoSERV defines a query language using CDDL that can be serialized in CBOR format, enabling interoperability across diverse systems.
+This document specifies the Concise Selector for Endorsements and Reference Values (CoSERV), a structured query/result format designed to facilitate the discovery and retrieval of these artifacts from various providers.
+CoSERV defines a query language and corresponding result structure using CDDL, which can be serialized in CBOR format, enabling efficient interoperability across diverse systems.
 
 --- middle
 
@@ -69,13 +69,18 @@ Remote Attestation Procedures (RATS) enable Relying Parties to evaluate the trus
 This appraisal necessitates access to Endorsements and Reference Values, which are often distributed across multiple providers, including hardware manufacturers, firmware developers, and software vendors.
 The lack of standardized methods for querying and retrieving these artifacts poses challenges in achieving seamless interoperability.
 
-The Concise Selector for Endorsements and Reference Values (CoSERV) addresses this challenge by defining a query language that allows Verifiers to specify the environment characteristics of the desired artifacts.
-This facilitates the efficient discovery and retrieval of relevant Endorsements and Reference Values from providers.
+The Concise Selector for Endorsements and Reference Values (CoSERV) addresses this challenge by defining a query language and a corresponding result structure for the transaction of artifacts between a provider and a consumer.
+The query language format provides Verifiers with a standard way to specify the environment characteristics of Attesters, such that the relevant artifacts can be obtained from Endorsers and Reference Value Providers.
+In turn, the result format allows those Endorsers and Reference Value Providers to package the artifacts within a standard structure.
+This facilitates the efficient discovery and retrieval of relevant Endorsements and Reference Values from providers, maximising the re-use of common software tools and libraries within the transactions.
 
 The CoSERV query language is intended to form the input data type for tools and services that provide access to Endorsements and Reference Values.
+The CoSERV result set is intended to form the corresponding output data type from those tools and services.
 This document does not define the complete APIs or interaction models for such tools and services.
-Nor does this document constrain the format of the output data that such tools and services might produce.
-The scope of this document is limited to the definition of the query language only.
+The scope of this document is limited to the definitions of the query language and the result set only.
+
+Both the query language and the result set are designed for extensibility.
+This addresses the need for a common baseline format to optimise for interoperability and software reuse, while maintaining the flexibility demanded by a dynamic and diverse ecosystem.
 
 The environment characteristics of Endorsements and Reference Values are derived from the equivalent concepts in CoRIM {{-rats-corim}}.
 CoSERV therefore borrows heavily from CoRIM, and shares some data types for its fields.

--- a/draft-howard-rats-coserv.md
+++ b/draft-howard-rats-coserv.md
@@ -44,12 +44,12 @@ normative:
     -: cbor
     =: RFC8949
   RFC9334: rats-arch
+  I-D.ietf-rats-corim: rats-corim
 
 informative:
   RFC6024: TA requirements
   RFC7942: Improving Awareness of Running Code
   I-D.ietf-rats-endorsements: rats-endorsements
-  I-D.ietf-rats-corim: rats-corim
   I-D.ietf-rats-eat: rats-eat
 
 entity:


### PR DESCRIPTION
A round of extensions and refactoring to match the draft prose to the CDDL data model.

- Introduction is rewritten to expand the scope of CoSERV to include both queries _and_ result sets.
- A new top-level "Information Model" section is introduced, so that we can keep informational concepts and structure distinct from the precise data model.
- Top-level "CoSERV Query Language" heading changed to "Data Model"
- CDDL section refactored to reflect the new top-level wrapper object, with the query now nested within it.

This is just a minimal set to make the prose more honest with respect to the CDDL. After this, we can probably do more refactoring to lift some verbosity out of the data model and put it into the information model instead.

Signed-off-by: Paul Howard <paul.howard@arm.com>