### PR TITLE
Stitch the result set example into the prose.

### DIFF
--- a/draft-howard-rats-coserv.md
+++ b/draft-howard-rats-coserv.md
@@ -299,7 +299,9 @@ In this next example, the query is a reference value query based on class.
 The top-level structure is a map with three entries: `profile` (codepoint 0), `query` (codepoint 1) and `results` (codepoint 2).
 
 The profile and query structures are the same as in the previous examples.
-The result structure is a map with two entries: `expiry` (codepoint 10) and `reference-value triples` (codepoint 0). A single reference-value triple is shown in this example. Its `environment-map`, as expected, is the same as the `environment-map` that was supplied in the query. The rest of the structure is the `measurement-map` as defined in CoRIM {{-rats-corim}}.
+The result structure is a map with two entries: `expiry` (codepoint 10) and `reference-value triples` (codepoint 0).
+A single reference-value triple is shown in this example. Its `environment-map`, as expected, is the same as the `environment-map` that was supplied in the query.
+The rest of the structure is the `measurement-map` as defined in CoRIM {{-rats-corim}}.
 
 ~~~edn
 {::include-fold cddl/examples/rv-results.diag}

--- a/draft-howard-rats-coserv.md
+++ b/draft-howard-rats-coserv.md
@@ -264,6 +264,8 @@ Other header parameters MAY be added to the header buckets, for example a `kid` 
 
 # Examples
 
+## Query Data Examples
+
 This section provides some illustrative examples of valid CoSERV query objects.
 
 The following example shows a query for Reference Values scoped by a single class.
@@ -286,6 +288,21 @@ Again, the `artifact-type` is set to 2, and `profile` is given a demonstration v
 
 ~~~edn
 {::include-fold cddl/examples/rv-instance-two-entries.diag}
+~~~
+
+## Result Data Examples
+
+This section provides some illustrative examples of valid CoSERV queries with their corresponding result sets.
+
+In this next example, the query is a reference value query based on class.
+
+The top-level structure is a map with three entries: `profile` (codepoint 0), `query` (codepoint 1) and `results` (codepoint 2).
+
+The profile and query structures are the same as with the previous examples above.
+The result structure is a map with two entries: `expiry` (codepoint 10) and `reference-value triples` (codepoint 0). A single reference-value triple is shown in this example. Its `environment-map`, as expected, is the same as the `environment-map` that was supplied in the query. The rest of the structure is the `measurement-map` as defined in CoRIM {{-rats-corim}}.
+
+~~~edn
+{::include-fold cddl/examples/rv-results.diag}
 ~~~
 
 # Implementation Status

--- a/draft-howard-rats-coserv.md
+++ b/draft-howard-rats-coserv.md
@@ -298,7 +298,7 @@ In this next example, the query is a reference value query based on class.
 
 The top-level structure is a map with three entries: `profile` (codepoint 0), `query` (codepoint 1) and `results` (codepoint 2).
 
-The profile and query structures are the same as with the previous examples above.
+The profile and query structures are the same as in the previous examples.
 The result structure is a map with two entries: `expiry` (codepoint 10) and `reference-value triples` (codepoint 0). A single reference-value triple is shown in this example. Its `environment-map`, as expected, is the same as the `environment-map` that was supplied in the query. The rest of the structure is the `measurement-map` as defined in CoRIM {{-rats-corim}}.
 
 ~~~edn


### PR DESCRIPTION
Splits the examples section into two subsections. Existing examples were query examples. The new example (just one so far) is query+result.
