### PR TITLE
Introduce the CDDL model for well-known API endpoint discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 cddl_deps := cddl/coserv-autogen.cddl
 cddl_deps += cddl/comid-autogen.cddl
 cddl_deps += cddl/signed-coserv-autogen.cddl
+cddl_deps += cddl/discovery-autogen.cddl
 
 $(drafts_xml): $(cddl_deps)
 

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -12,7 +12,7 @@ clean: ; rm -f $(CLEANFILES)
 
 $(eval $(call cddl_check_template,coserv,$(COSERV_FRAGS),$(COSERV_EXAMPLES),$(COSERV_IMPORT)))
 $(eval $(call cddl_check_template,signed-coserv,$(COSERV_SIGNED_FRAGS),$(COSERV_SIGNED_EXAMPLES),$(COSERV_SIGNED_IMPORT)))
-$(eval $(call cddl_check_template,discovery,$(DISCOVERY_FRAGS),$(DISCOVERY_CBOR_EXAMPLES),$(DISCOVERY_IMPORT)))
+$(eval $(call cddl_check_template,discovery,$(DISCOVERY_FRAGS),$(DISCOVERY_EXAMPLES),$(DISCOVERY_IMPORT)))
 
 include signed-examples.mk
 include subst.mk

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -4,6 +4,7 @@ include frags.mk
 
 check:: check-coserv check-coserv-examples
 check:: check-signed-coserv check-signed-coserv-examples
+check:: check-discovery check-discovery-examples
 .PHONY: check
 
 clean: ; rm -f $(CLEANFILES)
@@ -11,8 +12,10 @@ clean: ; rm -f $(CLEANFILES)
 
 $(eval $(call cddl_check_template,coserv,$(COSERV_FRAGS),$(COSERV_EXAMPLES),$(COSERV_IMPORT)))
 $(eval $(call cddl_check_template,signed-coserv,$(COSERV_SIGNED_FRAGS),$(COSERV_SIGNED_EXAMPLES),$(COSERV_SIGNED_IMPORT)))
+$(eval $(call cddl_check_template,discovery,$(DISCOVERY_FRAGS),$(DISCOVERY_CBOR_EXAMPLES),$(DISCOVERY_IMPORT)))
 
 include signed-examples.mk
 include subst.mk
 include comid.mk
 include cmw.mk
+include jwk.mk

--- a/cddl/check.mk
+++ b/cddl/check.mk
@@ -23,8 +23,6 @@ check-$(1)-examples: $(1)-autogen.cddl $(3:.diag=.cbor)
 	@for f in $(3:.diag=.cbor); do \
     echo ">> validating $$$$f against $$<" ; \
     $$(cddl) $$< validate $$$$f &>/dev/null || exit 1 ; \
-    echo ">> saving prettified CBOR to $$$${f%.cbor}.pretty" ; \
-    $$(cbor2pretty) $$$$f > $$$${f%.cbor}.pretty ; \
   done
 
 .PHONY: check-$(1)-examples

--- a/cddl/discovery.cddl
+++ b/cddl/discovery.cddl
@@ -19,13 +19,14 @@ version = tstr
 
 capability = {
     media-type-label => cmw.media-type,
-    supports-collected-label => bool,
-    supports-source-label => bool
+    artifact-support-label => artifact-support
 }
 
 media-type-label = eat.JC<"media-type", 1>
-supports-collected-label = eat.JC<"supports-collected", 2>
-supports-source-label = eat.JC<"supports-source", 3>
+artifact-support-label = eat.JC<"artifact-support", 2>
+
+non-empty-array<M> = (M) .and ([ + any ])
+artifact-support = non-empty-array<[ ? "source", ? "collected" ]>
 
 endpoint = {
     name-label => tstr,

--- a/cddl/discovery.cddl
+++ b/cddl/discovery.cddl
@@ -1,0 +1,36 @@
+;# import rfc9711 as eat
+;# import cmw-autogen as cmw
+;# import rfc9052 as cose
+;# import jwk-autogen as jwk
+
+coserv-well-known-info = {
+  version-label => version,
+  capabilities-label => [ + capability ],
+  api-endpoints-label => [ + endpoint ],
+  result-verification-key-label => eat.JC<jwk.JWK_Set, cose.COSE_KeySet>
+}
+
+version-label = eat.JC<"version", 1>
+capabilities-label = eat.JC<"capabilities", 2>
+api-endpoints-label = eat.JC<"api-endpoints", 3>
+result-verification-key-label = eat.JC<"result-verification-key", 4>
+
+version = tstr
+
+capability = {
+    media-type-label => cmw.media-type,
+    supports-collected-label => bool,
+    supports-source-label => bool
+}
+
+media-type-label = eat.JC<"media-type", 1>
+supports-collected-label = eat.JC<"supports-collected", 2>
+supports-source-label = eat.JC<"supports-source", 3>
+
+endpoint = {
+    name-label => tstr,
+    path-label => tstr
+}
+
+name-label = eat.JC<"name", 1>
+path-label = eat.JC<"path", 2>

--- a/cddl/examples/discovery-single-capability.diag
+++ b/cddl/examples/discovery-single-capability.diag
@@ -3,8 +3,10 @@
   / capabilities / 2: [
     {
       / media-type / 1: "application/coserv+cose; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
-      / supports-collected / 2: true,
-      / supports-source / 3: false
+      / artifact-support / 2: [
+        "source",
+        "collected"
+      ]
     }
   ],
   / api-endpoints / 3: [

--- a/cddl/examples/discovery-single-capability.diag
+++ b/cddl/examples/discovery-single-capability.diag
@@ -1,0 +1,26 @@
+{
+  / version / 1: "1.2.3-beta",
+  / capabilities / 2: [
+    {
+      / media-type / 1: "application/coserv+cose; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
+      / supports-collected / 2: true,
+      / supports-source / 3: false
+    }
+  ],
+  / api-endpoints / 3: [
+    {
+      / name / 1: "CoSERVRequestResponse",
+      / path / 2: "endorsement-distribution/v1/coserv"
+    }
+  ],
+  / result-verification-key / 4: [
+    {
+      / kty / 1: 2,
+      / alg / 3: -7,
+      / crv / -1: 1,
+      / x / -2: h'1A2B3C4D',
+      / y / -3: h'5E6F7A8B',
+      / kid / 2: h'ABCDEF1234'
+    }
+  ]
+}

--- a/cddl/examples/discovery-single-capability.json
+++ b/cddl/examples/discovery-single-capability.json
@@ -3,8 +3,8 @@
      "capabilities": [
       {
         "media-type": "application/coserv+cose; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
-        "supports-collected": "true",
-        "supports-source": "false"
+        "supports-collected": true,
+        "supports-source": false
       }
     ],
     "api-endpoints": [

--- a/cddl/examples/discovery-single-capability.json
+++ b/cddl/examples/discovery-single-capability.json
@@ -3,8 +3,10 @@
      "capabilities": [
       {
         "media-type": "application/coserv+cose; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
-        "supports-collected": true,
-        "supports-source": false
+        "artifact-support": [
+          "source",
+          "collected"
+        ]
       }
     ],
     "api-endpoints": [

--- a/cddl/examples/discovery-single-capability.json
+++ b/cddl/examples/discovery-single-capability.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.2.3-beta",
+     "capabilities": [
+      {
+        "media-type": "application/coserv+cose; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
+        "supports-collected": "true",
+        "supports-source": "false"
+      }
+    ],
+    "api-endpoints": [
+      {
+        "name": "CoSERVRequestResponse",
+        "path": "endorsement-distribution/v1/coserv"
+      }
+    ],
+    "result-verification-key": [
+      {
+        "alg": "ES256",
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
+        "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
+        "kid": "key1"
+      }
+    ]
+  }
+  

--- a/cddl/frags.mk
+++ b/cddl/frags.mk
@@ -15,3 +15,8 @@ COSERV_SIGNED_FRAGS += $(COSERV_FRAGS)
 COSERV_SIGNED_EXAMPLES := $(subst rv-,signed-rv-,$(COSERV_EXAMPLES))
 
 COSERV_SIGNED_IMPORT := $(COSERV_IMPORT)
+
+DISCOVERY_FRAGS := discovery.cddl
+DISCOVERY_IMPORT := cmw=cmw-autogen
+DISCOVERY_IMPORT := jwk=jwk-autogen
+DISCOVERY_CBOR_EXAMPLES := $(wildcard examples/discovery-*.diag)

--- a/cddl/frags.mk
+++ b/cddl/frags.mk
@@ -19,4 +19,5 @@ COSERV_SIGNED_IMPORT := $(COSERV_IMPORT)
 DISCOVERY_FRAGS := discovery.cddl
 DISCOVERY_IMPORT := cmw=cmw-autogen
 DISCOVERY_IMPORT := jwk=jwk-autogen
-DISCOVERY_CBOR_EXAMPLES := $(wildcard examples/discovery-*.diag)
+DISCOVERY_EXAMPLES := $(wildcard examples/discovery-*.diag)
+DISCOVERY_EXAMPLES += $(wildcard examples/discovery-*.json)

--- a/cddl/jwk.mk
+++ b/cddl/jwk.mk
@@ -1,0 +1,6 @@
+# JWK CDDL
+jwk_url := https://raw.githubusercontent.com/paulhowardarm/jose-cddl/refs/heads/main/jwk.cddl
+
+jwk-autogen.cddl: ; $(curl) $(jwk_url) > $@
+
+CLEANFILES += jwk-autogen.cddl

--- a/cddl/rfc9711.cddl
+++ b/cddl/rfc9711.cddl
@@ -1,0 +1,271 @@
+time-int = #6.1(int)
+
+binary-data = JC< base64-url-text, bstr>
+
+base64-url-text = tstr .regexp "[A-Za-z0-9_-]+"
+
+general-oid = JC< json-oid, ~oid >
+
+json-oid = tstr .regexp "([0-2])((\\.0)|(\\.[1-9][0-9]*))*"
+
+general-uri = JC< text, ~uri >
+
+coap-content-format = uint .le 65535
+
+
+$$Claims-Set-Claims //=
+    (nonce-label => nonce-type / [ 2* nonce-type ])
+
+nonce-type = JC< tstr .size (8..88), bstr .size (8..64)>
+
+
+$$Claims-Set-Claims //= (ueid-label => ueid-type)
+
+ueid-type-binary = bstr .size (7..33)
+ueid-type-text = tstr .b64u ueid-type-binary
+ueid-type = JC<ueid-type-text, ueid-type-binary>
+
+$$Claims-Set-Claims //= (sueids-label => sueids-type)
+
+sueids-type = {
+    + tstr => ueid-type
+}
+
+$$Claims-Set-Claims //= (
+    oemid-label => oemid-pen / oemid-ieee / oemid-random
+)
+
+oemid-pen = int
+
+oemid-ieee = JC<oemid-ieee-json, oemid-ieee-cbor>
+oemid-ieee-cbor = bstr .size 3
+oemid-ieee-json = tstr .b64u oemid-ieee-cbor
+
+oemid-random = JC<oemid-random-json, oemid-random-cbor>
+oemid-random-cbor = bstr .size 16
+oemid-random-json = tstr .b64u oemid-random-cbor
+
+
+$$Claims-Set-Claims //=  (
+    hardware-version-label => hardware-version-type
+)
+
+hardware-version-type = [
+    version:  tstr,
+    ? scheme:  $version-scheme
+]
+
+$$Claims-Set-Claims //= (
+    hardware-model-label => hardware-model-type
+)
+
+hardware-model-type-binary = bstr .size (1..32)
+hardware-model-type-text = tstr .b64u hardware-model-type-binary
+hardware-model-type = JC<hardware-model-type-text, hardware-model-type-binary>
+
+
+$$Claims-Set-Claims //= ( sw-name-label => tstr )
+
+$$Claims-Set-Claims //= (sw-version-label => sw-version-type)
+
+sw-version-type = [
+    version:  tstr
+    ? scheme:  $version-scheme
+]
+
+$$Claims-Set-Claims //= (oem-boot-label => bool)
+
+$$Claims-Set-Claims //= ( debug-status-label => debug-status-type )
+
+debug-status-type = ds-enabled /
+                    disabled /
+                    disabled-since-boot /
+                    disabled-permanently /
+                    disabled-fully-and-permanently
+
+ds-enabled                     = JC< "enabled", 0 >
+disabled                       = JC< "disabled", 1 >
+disabled-since-boot            = JC< "disabled-since-boot", 2 >
+disabled-permanently           = JC< "disabled-permanently", 3 >
+disabled-fully-and-permanently =
+                       JC< "disabled-fully-and-permanently", 4 >
+
+$$Claims-Set-Claims //= (location-label => location-type)
+
+location-type = {
+    latitude => number,
+    longitude => number,
+    ? altitude => number,
+    ? accuracy => number,
+    ? altitude-accuracy => number,
+    ? heading => number,
+    ? speed => number,
+    ? timestamp => ~time-int,
+    ? age => uint
+}
+
+latitude          = JC< "latitude",          1 >
+longitude         = JC< "longitude",         2 >
+altitude          = JC< "altitude",          3 >
+accuracy          = JC< "accuracy",          4 >
+altitude-accuracy = JC< "altitude-accuracy", 5 >
+heading           = JC< "heading",           6 >
+speed             = JC< "speed",             7 >
+timestamp         = JC< "timestamp",         8 >
+age               = JC< "age",               9 >
+
+$$Claims-Set-Claims //= (uptime-label => uint)
+
+$$Claims-Set-Claims //=  (boot-seed-label => binary-data)
+
+$$Claims-Set-Claims //= (boot-count-label => uint)
+
+$$Claims-Set-Claims //= ( intended-use-label => intended-use-type )
+
+intended-use-type = JC< text, int>
+
+$$Claims-Set-Claims //= (
+    dloas-label => [ + dloa-type ]
+)
+
+dloa-type = [
+    dloa_registrar: general-uri
+    dloa_platform_label: text
+    ? dloa_application_label: text
+]
+
+$$Claims-Set-Claims //= (profile-label => general-uri / general-oid)
+
+$$Claims-Set-Claims //= (
+    manifests-label => manifests-type
+)
+
+manifests-type = [+ manifest-format]
+
+manifest-format = [
+    content-type:   coap-content-format,
+    content-format: JC< $manifest-body-json,
+                        $manifest-body-cbor >
+]
+
+$manifest-body-cbor /= bytes .cbor untagged-coswid
+$manifest-body-json /= base64-url-text
+
+
+$$Claims-Set-Claims //= (
+    measurements-label => measurements-type
+)
+
+measurements-type = [+ measurements-format]
+
+measurements-format = [
+    content-type:   coap-content-format,
+    content-format: JC< $measurements-body-json,
+                        $measurements-body-cbor >
+]
+
+$measurements-body-cbor /= bytes .cbor untagged-coswid
+$measurements-body-json /= base64-url-text
+
+
+$$Claims-Set-Claims //= (
+    measurement-results-label =>
+        [ + measurement-results-group ] )
+
+measurement-results-group = [
+    measurement-system: tstr,
+    measurement-results: [ + individual-result ]
+]
+
+individual-result = [
+    result-id:  tstr / binary-data,
+    result:     result-type,
+]
+
+result-type = comparison-success /
+              comparison-fail /
+              comparison-not-run /
+              measurement-absent
+
+comparison-success       = JC< "success",       1 >
+comparison-fail          = JC< "fail",          2 >
+comparison-not-run       = JC< "not-run",       3 >
+measurement-absent       = JC< "absent",        4 >
+
+
+
+Detached-Submodule-Digest = [
+   hash-algorithm : text / int,
+   digest         : binary-data
+]
+
+
+BUNDLE-Messages = BUNDLE-Tagged-Message / BUNDLE-Untagged-Message
+
+BUNDLE-Tagged-Message   = #6.602(BUNDLE-Untagged-Message)
+BUNDLE-Untagged-Message = Detached-EAT-Bundle
+
+Detached-EAT-Bundle = [
+    main-token : Nested-Token,
+    detached-claims-sets: {
+        + tstr => JC<json-wrapped-claims-set,
+                     cbor-wrapped-claims-set>
+    }
+]
+
+json-wrapped-claims-set = base64-url-text
+
+cbor-wrapped-claims-set = bstr .cbor Claims-Set
+
+
+
+nonce-label                = JC< "eat_nonce",    10 >
+ueid-label                 = JC< "ueid",         256 >
+sueids-label               = JC< "sueids",       257 >
+oemid-label                = JC< "oemid",        258 >
+hardware-model-label       = JC< "hwmodel",      259 >
+hardware-version-label     = JC< "hwversion",    260 >
+uptime-label               = JC< "uptime",       261 >
+oem-boot-label             = JC< "oemboot",      262 >
+debug-status-label         = JC< "dbgstat",      263 >
+location-label             = JC< "location",     264 >
+profile-label              = JC< "eat_profile",  265 >
+submods-label              = JC< "submods",      266 >
+boot-count-label           = JC< "bootcount",    267 >
+boot-seed-label            = JC< "bootseed",     268 >
+dloas-label                = JC< "dloas",        269 >
+sw-name-label              = JC< "swname",       270 >
+sw-version-label           = JC< "swversion",    271 >
+manifests-label            = JC< "manifests",    272 >
+measurements-label         = JC< "measurements", 273 >
+measurement-results-label  = JC< "measres" ,     274 >
+intended-use-label         = JC< "intuse",       275 >
+
+
+Claims-Set = {
+    * $$Claims-Set-Claims
+    * Claim-Label .feature "extended-claims-label" => any
+}
+Claim-Label = int / text
+string-or-uri = text
+
+$$Claims-Set-Claims //= ( iss-claim-label => string-or-uri  )
+$$Claims-Set-Claims //= ( sub-claim-label => string-or-uri  )
+$$Claims-Set-Claims //= ( aud-claim-label => string-or-uri  )
+$$Claims-Set-Claims //= ( exp-claim-label => ~time )
+$$Claims-Set-Claims //= ( nbf-claim-label => ~time )
+$$Claims-Set-Claims //= ( iat-claim-label => ~time )
+$$Claims-Set-Claims //= ( cti-claim-label => bytes )
+
+iss-claim-label = JC<"iss", 1>
+sub-claim-label = JC<"sub", 2>
+aud-claim-label = JC<"aud", 3>
+exp-claim-label = JC<"exp", 4>
+nbf-claim-label = JC<"nbf", 5>
+iat-claim-label = JC<"iat", 6>
+cti-claim-label = CBOR-ONLY<7>  ; jti in JWT: different name and text
+
+JSON-ONLY<J> = J .feature "json"
+CBOR-ONLY<C> = C .feature "cbor"
+
+JC<J,C> = JSON-ONLY<J> / CBOR-ONLY<C>


### PR DESCRIPTION
Adds a CDDL file and corresponding makefile infrastructure to validate both the schema and examples in CBOR and JSON.

The CDDL from EAT (rfc9711) is included verbatim because the tooling has not yet caught up with this relatively-new RFC. We only use EAT for the `JC` macro, which is a useful tool for parameterising the model to account for the differences between JSON and CBOR serialisation. (This hasn't been needed up until now, because most of CoSERV is CBOR-only, but this new CDDL file is a data model for API discovery, which is separate from the CoSERV query language itself.)

There are no updates to the draft itself at this stage. Those will be made in a separate PR.

Signed-off-by: Paul Howard <paul.howard@arm.com>